### PR TITLE
fix: remove mix env check

### DIFF
--- a/lib/arke_postgres.ex
+++ b/lib/arke_postgres.ex
@@ -16,7 +16,8 @@ defmodule ArkePostgres do
   alias ArkePostgres.{Table, ArkeUnit}
 
   def init() do
-    case check_env(Mix.env()) do
+
+    case check_env() do
       {:ok, nil} ->
         try do
           projects =
@@ -49,9 +50,7 @@ defmodule ArkePostgres do
 
   def print_missing_env(keys), do: print_missing_env([keys])
 
-  def check_env(:test), do: {:ok, nil}
-
-  def check_env(_env) do
+  def check_env() do
     keys = ["DB_NAME", "DB_HOSTNAME", "DB_USER", "DB_PASSWORD"]
 
     key_map =

--- a/lib/mix/tasks/arke_postgres.create_project.ex
+++ b/lib/mix/tasks/arke_postgres.create_project.ex
@@ -42,7 +42,7 @@ defmodule Mix.Tasks.ArkePostgres.CreateProject do
   end
 
   def run(args) do
-    case ArkePostgres.check_env(Mix.env()) do
+    case ArkePostgres.check_env() do
       {:ok, _} ->
         [:postgrex, :ecto_sql, :arke]
         |> Enum.each(&Application.ensure_all_started/1)

--- a/lib/mix/tasks/arke_postgres.init_db.ex
+++ b/lib/mix/tasks/arke_postgres.init_db.ex
@@ -53,7 +53,7 @@ defmodule Mix.Tasks.ArkePostgres.InitDb do
   def run(args) do
     {opts, _} = OptionParser.parse!(args, strict: @switches, aliases: @aliases)
 
-    case ArkePostgres.check_env(Mix.env()) do
+    case ArkePostgres.check_env() do
       {:ok, _} ->
         [:postgrex, :ecto_sql, :arke_auth, :arke]
         |> Enum.each(&Application.ensure_all_started/1)


### PR DESCRIPTION
## Description
The env variables for ecto are not skipped in test environment. They must be set