### PR TITLE
chore!: raise elixir floor to ~> 1.16

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -13,7 +13,7 @@ defmodule ArkePostgres.MixProject do
       config_path: "./config/config.exs",
       deps_path: "./deps",
       lockfile: "./mix.lock",
-      elixir: "~> 1.13",
+      elixir: "~> 1.16",
       source_url: @scm_url,
       homepage_url: @site_url,
       description: description(),


### PR DESCRIPTION
## Description

Raises the declared Elixir requirement from `~> 1.13` to `~> 1.16`, the agreed
policy floor.

Breaking for 1.13 to 1.15 consumers. Ships with the next minor.

## Docs
- [ ] I have updated the docs accordingly

## Test

- [ ] I have added tests that prove my fix is effective or that my feature works

Suite green, no code changes: 81 tests, 0 failures.
