### PR TITLE
chore: format pass and lint CI leg

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,5 @@
+# Used by "mix format"
+[
+  import_deps: [:ecto_sql],
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
             otp: "26.2.5"
           - elixir: "1.18.4"
             otp: "26.2.5"
+            lint: lint
     services:
       postgres:
         image: postgres
@@ -55,6 +56,9 @@ jobs:
         run: mix deps.get
       - name: Compile dependencies
         run: mix deps.compile
+      - name: Ensure files are formatted
+        run: mix format --check-formatted
+        if: ${{ matrix.lint }}
       - name: Build package
         run: mix hex.build
       - name: Run tests

--- a/lib/mix/tasks/arke_postgres.create_member.ex
+++ b/lib/mix/tasks/arke_postgres.create_member.ex
@@ -41,14 +41,14 @@ defmodule Mix.Tasks.ArkePostgres.CreateMember do
     project: :string,
     username: :string,
     password: :string,
-  email: :string
+    email: :string
   ]
 
   @impl true
   def run(argv) do
     case ArkePostgres.check_env() do
       {:ok, _} ->
-        [:postgrex, :ecto_sql, :arke_auth, :arke,:arke_postgres]
+        [:postgrex, :ecto_sql, :arke_auth, :arke, :arke_postgres]
         |> Enum.each(&Application.ensure_all_started/1)
 
         case ArkePostgres.Repo.start_link() do
@@ -73,47 +73,53 @@ defmodule Mix.Tasks.ArkePostgres.CreateMember do
         Mix.Tasks.Help.run(["arke_postgres.create_member"])
 
       {data, _opts} ->
-      project = Keyword.fetch!(data,:project)
-      username = Keyword.get(data,:username,"admin")
-      password = Keyword.get(data,:password,"admin")
-      check_user(String.to_atom(project),username,password,data)
-
-      end
+        project = Keyword.fetch!(data, :project)
+        username = Keyword.get(data, :username, "admin")
+        password = Keyword.get(data, :password, "admin")
+        check_user(String.to_atom(project), username, password, data)
+    end
   end
 
-  defp check_user(project_id,username,password,opts)do
+  defp check_user(project_id, username, password, opts) do
     case QueryManager.get_by(project: :arke_system, arke_id: :user, username: username) do
-      nil -> create_user(project_id,username,password,opts)
-      %Arke.Core.Unit{}=user ->  create_member(project_id,user)
+      nil -> create_user(project_id, username, password, opts)
+      %Arke.Core.Unit{} = user -> create_member(project_id, user)
     end
   end
 
-  defp create_user(project_id,username,password,opts) do
+  defp create_user(project_id, username, password, opts) do
     user_model = ArkeManager.get(:user, :arke_system)
-    email = Keyword.get(opts,:email,"#{username}@bar.com")
-    data = %{username: username,password: password,email: email,type: "super_admin"}
-    with {:ok,user} <- QueryManager.create(:arke_system, user_model,data),
-         {:ok,_member} <- create_member(project_id,user)  do
-      IO.inspect("member #{username} created",syntax_colors: [string: :cyan])
-      :ok
-    else {:error,msg} ->
-    IO.inspect(msg)
-      :ok
-    end
+    email = Keyword.get(opts, :email, "#{username}@bar.com")
+    data = %{username: username, password: password, email: email, type: "super_admin"}
 
+    with {:ok, user} <- QueryManager.create(:arke_system, user_model, data),
+         {:ok, _member} <- create_member(project_id, user) do
+      IO.inspect("member #{username} created", syntax_colors: [string: :cyan])
+      :ok
+    else
+      {:error, msg} ->
+        IO.inspect(msg)
+        :ok
+    end
   end
 
-  defp create_member(project_id,user) do
-    case  ArkeManager.get(:super_admin,project_id) do
+  defp create_member(project_id, user) do
+    case ArkeManager.get(:super_admin, project_id) do
       nil ->
-        IO.inspect("super_admin is missing",syntax_colors: [string: :red])
+        IO.inspect("super_admin is missing", syntax_colors: [string: :red])
         :ok
-     model ->
-        case  QueryManager.get_by(project: project_id, arke_id: :super_admin, arke_system_user: user.id) do
+
+      model ->
+        case QueryManager.get_by(
+               project: project_id,
+               arke_id: :super_admin,
+               arke_system_user: user.id
+             ) do
           nil ->
-            QueryManager.create(project_id,model, arke_system_user: user.id)
+            QueryManager.create(project_id, model, arke_system_user: user.id)
+
           _ ->
-            IO.inspect("member already exists",syntax_colors: [string: :red])
+            IO.inspect("member already exists", syntax_colors: [string: :red])
             :ok
         end
     end

--- a/lib/mix/tasks/arke_postgres.create_project.ex
+++ b/lib/mix/tasks/arke_postgres.create_project.ex
@@ -68,20 +68,24 @@ defmodule Mix.Tasks.ArkePostgres.CreateProject do
     ArkePostgres.create_project(%{arke_id: :arke_project, id: id})
 
     Mix.shell().info("--- Creating arke_project for #{id}--- ")
-    label = opts[:label] || String.capitalize(id) |> String.replace("_"," ") |> String.trim
-    description =  opts[:description] || "Arke for the schema #{id}"
-    now =  Arke.Utils.DatetimeHandler.now(:datetime)
-    data = %{label: %{value: label, datetime: now },
-      description: %{value: description, datetime: now } ,
-      type: %{value: "postgres_schema", datetime: now },
-    persistence: %{value: "arke_parameter", datetime: now }}
+    label = opts[:label] || String.capitalize(id) |> String.replace("_", " ") |> String.trim()
+    description = opts[:description] || "Arke for the schema #{id}"
+    now = Arke.Utils.DatetimeHandler.now(:datetime)
+
+    data = %{
+      label: %{value: label, datetime: now},
+      description: %{value: description, datetime: now},
+      type: %{value: "postgres_schema", datetime: now},
+      persistence: %{value: "arke_parameter", datetime: now}
+    }
+
     row = [
       id: id,
       arke_id: "arke_project",
       data: data,
       metadata: %{},
       inserted_at: now,
-      updated_at:  now
+      updated_at: now
     ]
 
     case ArkePostgres.Repo.insert(ArkePostgres.Tables.ArkeUnit.changeset(Enum.into(row, %{})),
@@ -104,6 +108,7 @@ defmodule Mix.Tasks.ArkePostgres.CreateProject do
   defp parse_args(args) do
     {options, _} =
       OptionParser.parse!(args, strict: [id: :string, label: :string, description: :string])
+
     options
   end
 end

--- a/test/arke_postgres/arke_unit_test.exs
+++ b/test/arke_postgres/arke_unit_test.exs
@@ -37,10 +37,16 @@ defmodule ArkePostgres.ArkeUnitTest do
       unit = Arke.Core.Unit.load(arke, id: "arke_unit_update", arke_unit_label: "before")
       {:ok, _} = ArkeUnit.insert(@project, arke, unit)
 
-      updated = Arke.Core.Unit.update(unit, arke_unit_label: "after", updated_at: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second))
+      updated =
+        Arke.Core.Unit.update(unit,
+          arke_unit_label: "after",
+          updated_at: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+        )
+
       ArkeUnit.update(@project, arke, updated)
 
-      assert QueryManager.get_by(id: :arke_unit_update, project: @project).data.arke_unit_label == "after"
+      assert QueryManager.get_by(id: :arke_unit_update, project: @project).data.arke_unit_label ==
+               "after"
     end
   end
 
@@ -75,7 +81,9 @@ defmodule ArkePostgres.ArkeUnitTest do
 
   describe "decode_unit_data/1" do
     test "unwraps the stored value envelope" do
-      assert ArkeUnit.decode_unit_data(%{"label" => %{"value" => "hello"}}) == %{"label" => "hello"}
+      assert ArkeUnit.decode_unit_data(%{"label" => %{"value" => "hello"}}) == %{
+               "label" => "hello"
+             }
     end
 
     test "keeps a bare value as is" do
@@ -94,7 +102,10 @@ defmodule ArkePostgres.ArkeUnitTest do
 
   describe "encode_unit_data/2" do
     test "keeps a declared parameter", %{arke: arke} do
-      assert Map.has_key?(ArkeUnit.encode_unit_data(arke, %{arke_unit_label: "hello"}), "arke_unit_label")
+      assert Map.has_key?(
+               ArkeUnit.encode_unit_data(arke, %{arke_unit_label: "hello"}),
+               "arke_unit_label"
+             )
     end
 
     test "drops an undeclared parameter", %{arke: arke} do

--- a/test/arke_postgres/persistence_test.exs
+++ b/test/arke_postgres/persistence_test.exs
@@ -33,18 +33,22 @@ defmodule ArkePostgres.PersistenceTest do
     test "writes the new value", %{arke: arke} do
       {:ok, unit} = ArkePostgres.create(@project, unit_for(arke, "persist_update"))
 
-      {:ok, _} = ArkePostgres.update(@project, Arke.Core.Unit.update(unit, persistence_label: "after"))
+      {:ok, _} =
+        ArkePostgres.update(@project, Arke.Core.Unit.update(unit, persistence_label: "after"))
 
-      assert QueryManager.get_by(id: :persist_update, project: @project).data.persistence_label == "after"
+      assert QueryManager.get_by(id: :persist_update, project: @project).data.persistence_label ==
+               "after"
     end
 
     test "leaves other units alone", %{arke: arke} do
       {:ok, unit} = ArkePostgres.create(@project, unit_for(arke, "persist_update_a"))
       {:ok, _} = ArkePostgres.create(@project, unit_for(arke, "persist_update_b", "before"))
 
-      {:ok, _} = ArkePostgres.update(@project, Arke.Core.Unit.update(unit, persistence_label: "after"))
+      {:ok, _} =
+        ArkePostgres.update(@project, Arke.Core.Unit.update(unit, persistence_label: "after"))
 
-      assert QueryManager.get_by(id: :persist_update_b, project: @project).data.persistence_label == "before"
+      assert QueryManager.get_by(id: :persist_update_b, project: @project).data.persistence_label ==
+               "before"
     end
   end
 

--- a/test/arke_postgres/query_test.exs
+++ b/test/arke_postgres/query_test.exs
@@ -11,7 +11,8 @@ defmodule ArkePostgres.QueryTest do
 
   alias Arke.Boundary.ParameterManager
 
-  defp base, do: QueryManager.query(project: :test_schema, arke: ArkeManager.get(:arke, :arke_system))
+  defp base,
+    do: QueryManager.query(project: :test_schema, arke: ArkeManager.get(:arke, :arke_system))
 
   defp param(id), do: ParameterManager.get(id, :arke_system)
 

--- a/test/arke_postgres/table_test.exs
+++ b/test/arke_postgres/table_test.exs
@@ -24,7 +24,6 @@ defmodule ArkePostgres.TableTest do
   end
 
   test "insert then get_by returns the row" do
-
     assert {1, _} = Table.insert(@project, @schema, row("table_insert"))
 
     row = Table.get_by(@project, @schema, @fields, id: "table_insert")
@@ -38,7 +37,6 @@ defmodule ArkePostgres.TableTest do
   end
 
   test "get_all returns every matching row" do
-
     Table.insert(@project, @schema, row("table_all_1"))
     Table.insert(@project, @schema, row("table_all_2"))
 
@@ -55,7 +53,6 @@ defmodule ArkePostgres.TableTest do
   end
 
   test "update changes only the matching row" do
-
     Table.insert(@project, @schema, row("table_update", %{"k" => "before"}))
     Table.insert(@project, @schema, row("table_untouched", %{"k" => "before"}))
 
@@ -70,7 +67,6 @@ defmodule ArkePostgres.TableTest do
   end
 
   test "delete removes the row" do
-
     Table.insert(@project, @schema, row("table_delete"))
     assert Table.get_by(@project, @schema, @fields, id: "table_delete") != nil
 

--- a/test/arke_postgres/tables/changeset_test.exs
+++ b/test/arke_postgres/tables/changeset_test.exs
@@ -29,7 +29,6 @@ defmodule ArkePostgres.Tables.ChangesetTest do
     end
   end
 
-
   describe "ArkeSchema.changeset/1" do
     test "rejects an empty row" do
       refute ArkePostgres.Tables.ArkeSchema.changeset(%{}).valid?

--- a/test/support/repo_case.ex
+++ b/test/support/repo_case.ex
@@ -80,7 +80,10 @@ defmodule ArkePostgres.RepoCase do
 
   defp count_of(relation, where, params) do
     %{rows: [[count]]} =
-      ArkePostgres.Repo.query!("SELECT count(*) FROM information_schema.#{relation} WHERE #{where}", params)
+      ArkePostgres.Repo.query!(
+        "SELECT count(*) FROM information_schema.#{relation} WHERE #{where}",
+        params
+      )
 
     count
   end


### PR DESCRIPTION
## Description

Adds `.formatter.exs`, the mechanical format pass, and a
`mix format --check-formatted` step in CI guarded by a `lint` flag on the 1.18.4
matrix leg.

`.formatter.exs` declares `import_deps: [:ecto_sql]` so the formatter leaves the
migration DSL paren-less as written.

## Docs
- [ ] I have updated the docs accordingly

## Test

- [ ] I have added tests that prove my fix is effective or that my feature works
